### PR TITLE
Use jupyter-server-proxy url for the iframe if jupyterlab is running inside k8s

### DIFF
--- a/R/renderShinyApp.R
+++ b/R/renderShinyApp.R
@@ -1,7 +1,7 @@
 #' Render Shiny Application in a Jupyter Notebook
-#' 
+#'
 #' @param ui The UI definition of the app.
-#' @param port The TCP port that the application should listen on (defaults to 3000).  
+#' @param port The TCP port that the application should listen on (defaults to 3000).
 #' @inheritParams shiny::shinyApp
 #' @importFrom IRdisplay display_html
 #' @import shiny
@@ -10,8 +10,8 @@
 #' @export
 
 renderShinyApp <- function(
-  ui = NULL, 
-  server = NULL, 
+  ui = NULL,
+  server = NULL,
   appFile = NULL,
   appDir = NULL,
   port = 3000
@@ -24,7 +24,7 @@ renderShinyApp <- function(
     app <- shiny::shinyAppDir(appDir)
   } else {
     stop(
-      "You must define either 'ui'/'server', 'appFile', or 'appDir'", 
+      "You must define either 'ui'/'server', 'appFile', or 'appDir'",
       call. = FALSE
     )
   }
@@ -44,12 +44,25 @@ renderShinyApp <- function(
     if (!rproc$is_alive()) stop(rproc$read_all_error())
     Sys.sleep(0.05)
   }
-  displayIframe(port = args$port)
+  host <- getShinyHost(port = args$port)
+  displayIframe(host)
 }
 
 
-displayIframe <- function(port) {
-  html <- sprintf('<iframe src="http://127.0.0.1:%s" width="100%%", height="800"></iframe>', port)
+getShinyHost <- function(port) {
+  jupyterUser <- Sys.getenv("JUPYTERHUB_USER")
+  # If jupyter is running inside k8s-hub create a url to use jupyter-server-proxy
+  if (jupyterUser != "" && Sys.getenv("JUPYTERHUB_API_URL") != "") {
+    host <- sprintf("/user/%s/proxy/%s", jupyterUser, port)
+    return(host)
+  }
+  host <- sprintf('http://127.0.0.1:%s', port)
+  return(host)
+}
+
+
+displayIframe <- function(host) {
+  html <- sprintf('<iframe src="%s" width="100%%", height="800"></iframe>', host)
   display_html(html)
 }
 

--- a/R/renderShinyApp.R
+++ b/R/renderShinyApp.R
@@ -51,8 +51,9 @@ renderShinyApp <- function(
 
 getShinyHost <- function(port) {
   jupyterUser <- Sys.getenv("JUPYTERHUB_USER")
+  jupyterApiURL <- Sys.getenv("JUPYTERHUB_API_URL", unset=NA)
   # If jupyter is running inside k8s-hub create a url to use jupyter-server-proxy
-  if (jupyterUser != "" && Sys.getenv("JUPYTERHUB_API_URL") != "") {
+  if (jupyterUser != "" && !is.na(jupyterApiURL)) {
     host <- sprintf("/user/%s/proxy/%s", jupyterUser, port)
     return(host)
   }

--- a/R/renderShinyApp.R
+++ b/R/renderShinyApp.R
@@ -54,7 +54,7 @@ getShinyHost <- function(port) {
   jupyterApiURL <- Sys.getenv("JUPYTERHUB_API_URL", unset=NA)
   # If jupyter is running inside k8s-hub create a url to use jupyter-server-proxy
   if (jupyterUser != "" && !is.na(jupyterApiURL)) {
-    host <- sprintf("/user/%s/proxy/%s", jupyterUser, port)
+    host <- sprintf("/user/%s/proxy/%s/", jupyterUser, port)
     return(host)
   }
   host <- sprintf('http://127.0.0.1:%s', port)


### PR DESCRIPTION
[jupyterhub/k8s-hub container is setting some custom env variables](https://zero-to-jupyterhub.readthedocs.io/en/latest/resources/reference.html?highlight=JUPYTERHUB_USER#singleuser-extraenv). Checking if these env variables are set we assume that jupyterlab is running inside kubernetes and use jupyter-server-proxy's endpoint to serve the shiny app.