### PR TITLE
Match iframe's height to the height of the viewport

### DIFF
--- a/R/renderShinyApp.R
+++ b/R/renderShinyApp.R
@@ -63,7 +63,7 @@ getShinyHost <- function(port) {
 
 
 displayIframe <- function(host) {
-  html <- sprintf('<iframe src="%s" width="100%%", height="800" style="border: 0;"></iframe>', host)
+  html <- sprintf('<iframe src="%s" width="100%%" style="border: 0;height: calc(100vh - 70px);margin: 0;"></iframe>', host)
   display_html(html)
 }
 


### PR DESCRIPTION
We can use **vh** unit, to match the viewport's height. That way we won't have 2 scrollbars inside our webapp when running in voila. Inside jupyterlab we have to take into consideration the height of jupyterlab's bar on top and bottom, while in voila there are no such elements only some top/bottom padding. So i removed 70 pixels from the full viewport so it looks good in both these occasions.

![image](https://user-images.githubusercontent.com/33217757/121669371-eaf85780-cab4-11eb-99d9-07d4b22e7810.png)

