### PR TITLE
Rename package to shinybg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,23 @@ Type: Package
 Title: Shiny applications in the background
 Description: Run and manage Shiny applications as background processes. With 'shinybg' you can launch a Shiny application without locking your current R session, run multiple applications at once, and embed them in Jupyter notebooks.
 Version: 0.1.4.9000
-Author: TileDB
-Maintainer: TileDB <hello@tiledb.com>
+Authors@R: c(
+    person(given = "Aaron",
+           family = "Wolen",
+           role = c("cre", "aut"),
+           email = "aaron@tiledb.com",
+           comment = c(ORCID = "0000-0003-2542-2202")),
+    person(given = "Kostas",
+           family = "Sarantopoulos",
+           role = "aut",
+           email = "kostas@tiledb.com"),
+    person(given = "Seth",
+           family = "Shelnutt",
+           role = "aut",
+           email = "seth@tiledb.com"),
+    person(given = "TileDB, Inc.",
+           role = c("cph", "fnd"))
+    )
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinybg
 Type: Package
-Title: Shiny apps in the background
+Title: Shiny applications in the background
 Description: Run and manage Shiny applications as background processes. With 'shinybg' you can launch a Shiny application without locking your current R session, run multiple applications at once, and embed them in Jupyter notebooks.
 Version: 0.1.4.9000
 Author: TileDB

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,6 @@
 Package: tiledbJupyterShiny
 Type: Package
-Title: Render Shiny apps inside a Jupyter notebook
-Version: 0.1.4
+Version: 0.1.4.9000
 Author: TileDB
 Maintainer: TileDB <hello@tiledb.com>
 Description: Render Shiny apps inside a Jupyter notebook.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,10 @@
-Package: tiledbJupyterShiny
+Package: shinybg
 Type: Package
+Title: Shiny apps in the background
+Description: Run and manage Shiny applications as background processes. With 'shinybg' you can launch a Shiny application without locking your current R session, run multiple applications at once, and embed them in Jupyter notebooks.
 Version: 0.1.4.9000
 Author: TileDB
 Maintainer: TileDB <hello@tiledb.com>
-Description: Render Shiny apps inside a Jupyter notebook.
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,12 @@ RUN mamba install -c conda-forge --quiet --yes \
   'r-pingr' \
   && mamba clean --all -f -y
 
-# install the tiledbJupyterShiny package
+# install the shinybg package
 WORKDIR /tmp
-COPY --chown=$NB_UID . tiledbJupyterShiny/
-RUN R CMD build tiledbJupyterShiny \
-  && R CMD INSTALL tiledbJupyterShiny_*.tar.gz \
-  && rm -rf tiledbJupyterShiny*
+COPY --chown=$NB_UID . shinybg/
+RUN R CMD build shinybg \
+  && R CMD INSTALL shinybg_*.tar.gz \
+  && rm -rf shinybg*
 
 # register kernel for current R installation
 RUN Rscript -e "IRkernel::installspec()"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2021 tiledbJupyterShiny authors
+Copyright (c) 2021 shinybg authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# shinybg (development version)
+
+* Rename package to *shinybg*
+
 # tiledbJupyterShiny 0.1.4
 
 * Adds `AppManager` class for managing background shiny apps

--- a/R/appManager.R
+++ b/R/appManager.R
@@ -7,7 +7,7 @@
 #' manager
 #'
 #' # Create background shiny apps
-#' app <- system.file("apps/sever-info-app.R", package = "tiledbJupyterShiny")
+#' app <- system.file("apps/sever-info-app.R", package = "shinybg")
 #' app1 <- runBackgroundApp(appFile = app, port = 3001)
 #' app2 <- runBackgroundApp(appFile = app, port = 3002)
 #'
@@ -35,7 +35,7 @@ AppManager <- R6::R6Class(
     #' @param x self
     #' @param ... ignored
     print = function(x, ...) {
-      cat("<tiledbJupyterShiny apps> ", sep = "\n")
+      cat("<shinybg apps> ", sep = "\n")
       if (length(self$apps) == 0) {
         cat("..No managed apps..", sep = "\n")
       } else {

--- a/R/runBackgroundApp.R
+++ b/R/runBackgroundApp.R
@@ -8,7 +8,7 @@
 #' @return A [callr::r_process] object for the background Shiny app
 #' @examples
 #' \dontrun{
-#' app <- system.file("apps/sever-info-app.R", package = "tiledbJupyterShiny")
+#' app <- system.file("apps/sever-info-app.R", package = "shinybg")
 #' bg_app <- runBackgroundApp(appFile = app, port = 3005)
 #' bg_app$kill()
 #' }

--- a/README.md
+++ b/README.md
@@ -2,36 +2,45 @@
 
 [![R-CMD-check](https://github.com/TileDB-Inc/shinybg/workflows/R-CMD-check/badge.svg)](https://github.com/TileDB-Inc/shinybg/actions)
 
-Run shiny apps as background processes.
-
 ## Overview
 
-Render shiny apps inside a jupyter notebook
+Run and manage Shiny applications as background processes.
 
+With *shinybg* you can:
 
-## Example
+* launch a Shiny application without locking your current R session
+* run multiple applications at once
+* embed application in Jupyter notebooks
 
-```
-library(shinybg)
-renderShinyApp(
-  appFile = system.file(
-    "inst/apps/sever-info-app.R",
-    package = "shinybg"
-  )
-)
-```
-## Running in Docker
+## Installation
 
-Test out extension in a Dockerized Jupyter environment.
+*shinybg* is currently under active development and is not yet available on CRAN. You can install the development from GitHub:
 
-
-Build the image:
-
-```
-docker build -t tiledb/tiledb-jupyter-shiny:latest .
+```r
+remotes::install_github("tiledb-inc/shinybg", remotes::github_release())
 ```
 
-Run the container:
+## Usage
+
+### Basic app management
+
+Create two instances of the same app on ports 3001 and 3002.
+
+```r
+app <- system.file("apps/sever-info-app.R", package = "shinybg")
+app1 <- runBackgroundApp(appFile = app, port = 3001)
+app2 <- runBackgroundApp(appFile = app, port = 3002)
+```
+
+### Jupyter integration
+
+You can test out embedding Shiny applications in a Jupter notebook using the provided [Dockerfile][]. Pre-built images are available on [Docker Hub](https://hub.docker.com/repository/docker/tiledb/shinybg) or you can build it yourself by running:
+
+```sh
+docker build -t tiledb/shinybg:latest .
+```
+
+Next, run the container, forwarding ports 8888 for the Jupyter server and 3000 for the embedded Shiny app.
 
 ```sh
 docker run --rm \
@@ -39,10 +48,10 @@ docker run --rm \
   -p 3000:3000 \
   -e JUPYTER_ENABLE_LAB=yes \
   -v $PWD/dev:/home/jovyan/work \
-  tiledb/tiledb-jupyter-shiny:latest
+  tiledb/shinybg:latest
 ```
 
-Launch an R-kernel Jupyter notebook, copy and paste the following chunk into the first cell, and then run it:
+Within the Jupyter environment, launch an R-kernel Jupyter notebook and paste the following chunk into the first cell:
 
 ```r
 library(shiny)
@@ -52,3 +61,10 @@ renderShinyApp(
     appFile = system.file("apps/sever-info-app.R", package = "shinybg")
 )
 ```
+
+## Get in touch
+
+- [@tiledb](https://twitter.com/tiledb)
+- [TileDB Community Slack](https://tiledb-community.slack.com)
+- [TileDB Support Forum](https://forum.tiledb.com)
+

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
-## Render shiny apps inside a jupyter notebook
+# shinybg
 
-[![R-CMD-check](https://github.com/TileDB-Inc/TileDB-Jupyter-Shiny/workflows/R-CMD-check/badge.svg)](https://github.com/TileDB-Inc/TileDB-Jupyter-Shiny/actions)
+[![R-CMD-check](https://github.com/TileDB-Inc/shinybg/workflows/R-CMD-check/badge.svg)](https://github.com/TileDB-Inc/shinybg/actions)
+
+Run shiny apps as background processes.
+
+## Overview
+
+Render shiny apps inside a jupyter notebook
+
+
 ## Example
 
 ```
-library(tiledbJupyterShiny)
+library(shinybg)
 renderShinyApp(
   appFile = system.file(
-    "inst/apps/sever-info-app.R", 
-    package = "tiledbJupyterShiny"
+    "inst/apps/sever-info-app.R",
+    package = "shinybg"
   )
 )
 ```
@@ -38,9 +46,9 @@ Launch an R-kernel Jupyter notebook, copy and paste the following chunk into the
 
 ```r
 library(shiny)
-library(tiledbJupyterShiny)
+library(shinybg)
 
 renderShinyApp(
-    appFile = system.file("apps/sever-info-app.R", package = "tiledbJupyterShiny")
+    appFile = system.file("apps/sever-info-app.R", package = "shinybg")
 )
 ```

--- a/dev/test-app.ipynb
+++ b/dev/test-app.ipynb
@@ -3,20 +3,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2934e7e5-89bd-4a44-bb8a-15a25a4ffe9b",
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "library(tiledbJupyterShiny)\n",
+    "library(shinybg)\n",
     "library(shiny)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7782a3a0-fa64-404c-929e-93470ca6130f",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "ui <- bootstrapPage(\n",
     "      numericInput('n', 'Number of obs', 25),\n",
@@ -28,17 +24,18 @@
     "        hist(runif(input$n))\n",
     "    })\n",
     "}"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ecd89a8e-9f5b-4974-9609-92db80ed2864",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "renderShinyApp(ui, server)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/inst/apps/vignette.ipynb
+++ b/inst/apps/vignette.ipynb
@@ -2,189 +2,170 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6f7e38f7-c98b-4d3a-9131-eaed6fae2e18",
-   "metadata": {},
    "source": [
     "# Managing Background Shiny Apps"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "0380b7d4-bc76-47f3-b132-2476c9c65f81",
-   "metadata": {},
    "source": [
-    "This notebook provides an overview of `tiledbJupyterShiny`'s app management functionality. "
-   ]
+    "This notebook provides an overview of `shinybg`'s app management functionality. "
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "745835ca-a1e5-444f-b3b3-8654a399165e",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "library(shiny)\n",
-    "library(tiledbJupyterShiny)"
-   ]
+    "library(shinybg)"
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "a7d72fcf-0f23-4af1-a604-39d0ad6235e7",
-   "metadata": {},
    "source": [
     "## Registration\n",
     "\n",
-    "Whenever a Shiny app is launched using `renderShinyApp()` or `runBackgroundApp()` it is registered with `tiledbJupyterShiny`'s app manager."
-   ]
+    "Whenever a Shiny app is launched using `renderShinyApp()` or `runBackgroundApp()` it is registered with `shinybg`'s app manager."
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28688adb-3156-42d0-a96f-e17aec10630a",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "app1 <- renderShinyApp(\n",
-    "    appFile = system.file(\"apps/histogram-app.R\", package = \"tiledbJupyterShiny\"),\n",
+    "    appFile = system.file(\"apps/histogram-app.R\", package = \"shinybg\"),\n",
     "    port = 3000\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "52f15475-816c-4a00-bd25-061da11b01d0",
-   "metadata": {},
    "source": [
     "You can Verify the app is registered and running:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8cfc6bef-1bea-4bad-8bb6-c6c354a9c2bf",
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "tiledbJupyterShiny:::app_manager"
-   ]
+    "shinybg:::app_manager"
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "f5c4632f-ce45-4737-b67b-3025964d313c",
-   "metadata": {},
    "source": [
     "Let's start another instance of the same app on a different port."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9f64deb-ec12-4c53-a37c-b282fb5f7a78",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "app2 <- renderShinyApp(\n",
-    "    appFile = system.file(\"apps/histogram-app.R\", package = \"tiledbJupyterShiny\"),\n",
+    "    appFile = system.file(\"apps/histogram-app.R\", package = \"shinybg\"),\n",
     "    port = 3001\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "1d1e91a8-79a2-43cd-b53f-84e52843560d",
-   "metadata": {},
    "source": [
     "Now verify boths apps appear in the manager:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d775e855-23b2-4205-ac0e-fbd3630bbc79",
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "tiledbJupyterShiny:::app_manager"
-   ]
+    "shinybg:::app_manager"
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "d65eedc0-4aca-4846-b8bb-b5848c4f732d",
-   "metadata": {},
    "source": [
     "## Management\n",
     "\n",
     "You can use the app manager to kill any of your background Shiny apps:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4b2acdc-39a5-45b4-bda3-17b44b785290",
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "tiledbJupyterShiny:::app_manager$kill_app(3000)"
-   ]
+    "shinybg:::app_manager$kill_app(3000)"
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "b4084e4c-21b5-447d-ac9f-cd4be3f2095f",
-   "metadata": {},
    "source": [
     "If you scroll up to the app's cell you'll see it is now greyed out, indicating it's been terminated."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "b6c21086-907b-43d6-ad74-bd41db5075f8",
-   "metadata": {},
    "source": [
     "If you attempt to launch an app on a port already in use the app manager will kill the existing app before starting the new one:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d974dd8-4e91-4862-96da-01615dce8af8",
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "system.file(\"apps/sever-info-app.R\", package = \"tiledbJupyterShiny\")"
-   ]
+    "system.file(\"apps/sever-info-app.R\", package = \"shinybg\")"
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39832725-c0c6-45bd-b76b-2c1d50e07bab",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "app3 <- renderShinyApp(\n",
-    "    appFile = system.file(\"apps/sever-info-app.R\", package = \"tiledbJupyterShiny\"),\n",
+    "    appFile = system.file(\"apps/sever-info-app.R\", package = \"shinybg\"),\n",
     "    port = 3001\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "03bea731-5a02-4ff9-a22b-d88553c4816e",
-   "metadata": {},
    "source": [
     "## Cleanup\n",
     "\n",
     "Finally, we can use the app manager to kill all running apps."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bc5185fe-f54b-4622-a5a2-1989bd92872d",
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "tiledbJupyterShiny:::app_manager$kill_all_apps()"
-   ]
+    "shinybg:::app_manager$kill_all_apps()"
+   ],
+   "outputs": [],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/man/AppManager.Rd
+++ b/man/AppManager.Rd
@@ -13,7 +13,7 @@ manager <- AppManager$new()
 manager
 
 # Create background shiny apps
-app <- system.file("apps/sever-info-app.R", package = "tiledbJupyterShiny")
+app <- system.file("apps/sever-info-app.R", package = "shinybg")
 app1 <- runBackgroundApp(appFile = app, port = 3001)
 app2 <- runBackgroundApp(appFile = app, port = 3002)
 

--- a/man/runBackgroundApp.Rd
+++ b/man/runBackgroundApp.Rd
@@ -47,7 +47,7 @@ Run Shiny App in a Background Process
 }
 \examples{
 \dontrun{
-app <- system.file("apps/sever-info-app.R", package = "tiledbJupyterShiny")
+app <- system.file("apps/sever-info-app.R", package = "shinybg")
 bg_app <- runBackgroundApp(appFile = app, port = 3005)
 bg_app$kill()
 }


### PR DESCRIPTION
This changes the package name to 'shinybg'. It also improves the package description and updates the README to add installation instructions, examples for running apps in the background outside of Jupyter, detailed instructions for using it w/ Jupyter via our Docker image, and links to TileDB resources.