### PR TITLE
Add options to set stdout/stderr locations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: shinybg
 Type: Package
 Title: Shiny applications in the background
 Description: Run and manage Shiny applications as background processes. With 'shinybg' you can launch a Shiny application without locking your current R session, run multiple applications at once, and embed them in Jupyter notebooks.
-Version: 0.1.5.9002
+Version: 0.1.5.9003
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",
@@ -30,4 +30,4 @@ Imports:
     callr,
     pingr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # shinybg (development version)
 
+* `runBackgroundApp()` and `renderShinyApp()` gain arguments for specifying the location of the app's stdout and stderr streams (#12)
 * Adds exported functions for app management
 * Update Docker hub repo name
 # shinybg v0.1.5

--- a/R/appManager.R
+++ b/R/appManager.R
@@ -1,5 +1,7 @@
 #' @title AppManager
 #' @description Manage shiny apps running in background tasks.
+#' @param port TCP port the app is listening on (e.g., 3000)
+#' @param verbose (logical) Should messages be printed to the console?
 #' @export
 #' @examples \dontrun{
 #' # Make a stub
@@ -49,8 +51,7 @@ AppManager <- R6::R6Class(
     },
 
     #' @description Register an app
-    #' @param port TCP port the app is listening on (e.g., 3000)
-    #' @param [callr::r_process] for a Shiny app
+    #' @param app [callr::r_process] for a Shiny app
     #' @return nothing returned
     register_app = function(port, app) {
       stopifnot(inherits(app, "r_process"))
@@ -65,7 +66,6 @@ AppManager <- R6::R6Class(
     },
 
     #' @description Retrieve a registered app
-    #' @param port TCP port the app is listening on (e.g., 3000)
     #' @return [callr::r_process] for a Shiny app
     retrieve_app = function(port) {
       port <- private$check_port_exists(port)
@@ -73,7 +73,6 @@ AppManager <- R6::R6Class(
     },
 
     #' @description View background Shiny application
-    #' @param port TCP port the app is listening on (e.g., 3000)
     #' @return (Invisibly) The application's URL.
     #' @importFrom utils browseURL
     view_app = function(port) {
@@ -101,7 +100,6 @@ AppManager <- R6::R6Class(
     },
 
     #' @description Kill an app's process and deregister it
-    #' @param port TCP port the app is listening on (e.g., 3000)
     #' @return `TRUE` if the process was terminated, and `FALSE` if it was not
     kill_app = function(port, verbose = TRUE) {
       port <- private$check_port_exists(port)

--- a/R/renderShinyApp.R
+++ b/R/renderShinyApp.R
@@ -11,12 +11,23 @@ renderShinyApp <- function(
   server = NULL,
   appFile = NULL,
   appDir = NULL,
-  port = 3000
+  port = 3000,
+  stdout = "|",
+  stderr = "|"
 ) {
 
   # hardcode host for rendering shiny within iframe
   host <- "0.0.0.0"
-  rproc <- runBackgroundApp(ui, server, appFile, appDir, port, host = host)
+  rproc <- runBackgroundApp(
+    ui = ui,
+    server = server,
+    appFile = appFile,
+    appDir = appDir,
+    port = port,
+    host = host,
+    stdout = stdout,
+    stderr = stderr
+  )
 
   while(!pingr::is_up(destination = host, port = port)) {
     if (!rproc$is_alive()) stop(rproc$read_all_error())
@@ -48,5 +59,3 @@ displayIframe <- function(host) {
   html <- sprintf('<iframe src="%s" width="100%%" style="border: 0;height: calc(100vh - 70px);margin: 0;"></iframe>', host)
   display_html(html)
 }
-
-

--- a/R/runBackgroundApp.R
+++ b/R/runBackgroundApp.R
@@ -4,6 +4,7 @@
 #' @param port The TCP port that the application should listen on (defaults to 3000).
 #' @inheritParams shiny::runApp
 #' @inheritParams shiny::shinyApp
+#' @inheritParams callr::r_bg
 #' @importFrom IRdisplay display_html
 #' @return A [callr::r_process] object for the background Shiny app
 #' @examples
@@ -22,7 +23,9 @@ runBackgroundApp <- function(
   appFile = NULL,
   appDir = NULL,
   port = getOption("shiny.port"),
-  host = getOption("shiny.host", "127.0.0.1")
+  host = getOption("shiny.host", "127.0.0.1"),
+  stdout = "|",
+  stderr = "|"
 ) {
   if (!is.null(ui) || !is.null(server)) {
     app <- shiny::shinyApp(ui, server)
@@ -49,8 +52,10 @@ runBackgroundApp <- function(
   app <- callr::r_bg(
     func = run_app,
     args = args,
-    supervise = TRUE
+    stdout = stdout,
+    stderr = stderr
   )
+
   app_manager$register_app(port, app)
   app
 }

--- a/man/AppManager.Rd
+++ b/man/AppManager.Rd
@@ -42,19 +42,19 @@ manager$kill_all_apps()
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-print}{\code{AppManager$print()}}
-\item \href{#method-register_app}{\code{AppManager$register_app()}}
-\item \href{#method-retrieve_app}{\code{AppManager$retrieve_app()}}
-\item \href{#method-view_app}{\code{AppManager$view_app()}}
-\item \href{#method-kill_app}{\code{AppManager$kill_app()}}
-\item \href{#method-kill_all_apps}{\code{AppManager$kill_all_apps()}}
-\item \href{#method-list_ports}{\code{AppManager$list_ports()}}
-\item \href{#method-clone}{\code{AppManager$clone()}}
+\item \href{#method-AppManager-print}{\code{AppManager$print()}}
+\item \href{#method-AppManager-register_app}{\code{AppManager$register_app()}}
+\item \href{#method-AppManager-retrieve_app}{\code{AppManager$retrieve_app()}}
+\item \href{#method-AppManager-view_app}{\code{AppManager$view_app()}}
+\item \href{#method-AppManager-kill_app}{\code{AppManager$kill_app()}}
+\item \href{#method-AppManager-kill_all_apps}{\code{AppManager$kill_all_apps()}}
+\item \href{#method-AppManager-list_ports}{\code{AppManager$list_ports()}}
+\item \href{#method-AppManager-clone}{\code{AppManager$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-print"></a>}}
-\if{latex}{\out{\hypertarget{method-print}{}}}
+\if{html}{\out{<a id="method-AppManager-print"></a>}}
+\if{latex}{\out{\hypertarget{method-AppManager-print}{}}}
 \subsection{Method \code{print()}}{
 print method for the \code{AppManager} class
 \subsection{Usage}{
@@ -72,8 +72,8 @@ print method for the \code{AppManager} class
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-register_app"></a>}}
-\if{latex}{\out{\hypertarget{method-register_app}{}}}
+\if{html}{\out{<a id="method-AppManager-register_app"></a>}}
+\if{latex}{\out{\hypertarget{method-AppManager-register_app}{}}}
 \subsection{Method \code{register_app()}}{
 Register an app
 \subsection{Usage}{
@@ -85,7 +85,7 @@ Register an app
 \describe{
 \item{\code{port}}{TCP port the app is listening on (e.g., 3000)}
 
-\item{\code{[callr::r_process]}}{for a Shiny app}
+\item{\code{app}}{\link[callr:r_process]{callr::r_process} for a Shiny app}
 }
 \if{html}{\out{</div>}}
 }
@@ -94,8 +94,8 @@ nothing returned
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-retrieve_app"></a>}}
-\if{latex}{\out{\hypertarget{method-retrieve_app}{}}}
+\if{html}{\out{<a id="method-AppManager-retrieve_app"></a>}}
+\if{latex}{\out{\hypertarget{method-AppManager-retrieve_app}{}}}
 \subsection{Method \code{retrieve_app()}}{
 Retrieve a registered app
 \subsection{Usage}{
@@ -114,8 +114,8 @@ Retrieve a registered app
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-view_app"></a>}}
-\if{latex}{\out{\hypertarget{method-view_app}{}}}
+\if{html}{\out{<a id="method-AppManager-view_app"></a>}}
+\if{latex}{\out{\hypertarget{method-AppManager-view_app}{}}}
 \subsection{Method \code{view_app()}}{
 View background Shiny application
 \subsection{Usage}{
@@ -134,8 +134,8 @@ View background Shiny application
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-kill_app"></a>}}
-\if{latex}{\out{\hypertarget{method-kill_app}{}}}
+\if{html}{\out{<a id="method-AppManager-kill_app"></a>}}
+\if{latex}{\out{\hypertarget{method-AppManager-kill_app}{}}}
 \subsection{Method \code{kill_app()}}{
 Kill an app's process and deregister it
 \subsection{Usage}{
@@ -146,6 +146,8 @@ Kill an app's process and deregister it
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{port}}{TCP port the app is listening on (e.g., 3000)}
+
+\item{\code{verbose}}{(logical) Should messages be printed to the console?}
 }
 \if{html}{\out{</div>}}
 }
@@ -154,21 +156,28 @@ Kill an app's process and deregister it
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-kill_all_apps"></a>}}
-\if{latex}{\out{\hypertarget{method-kill_all_apps}{}}}
+\if{html}{\out{<a id="method-AppManager-kill_all_apps"></a>}}
+\if{latex}{\out{\hypertarget{method-AppManager-kill_all_apps}{}}}
 \subsection{Method \code{kill_all_apps()}}{
 Kill all registered apps
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{AppManager$kill_all_apps(verbose = TRUE)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{verbose}}{(logical) Should messages be printed to the console?}
+}
+\if{html}{\out{</div>}}
+}
 \subsection{Returns}{
 Nothing returned
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-list_ports"></a>}}
-\if{latex}{\out{\hypertarget{method-list_ports}{}}}
+\if{html}{\out{<a id="method-AppManager-list_ports"></a>}}
+\if{latex}{\out{\hypertarget{method-AppManager-list_ports}{}}}
 \subsection{Method \code{list_ports()}}{
 List ports used by registered apps
 \subsection{Usage}{
@@ -180,8 +189,8 @@ Character vector with 0 or more elements
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-AppManager-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-AppManager-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/renderShinyApp.Rd
+++ b/man/renderShinyApp.Rd
@@ -9,7 +9,9 @@ renderShinyApp(
   server = NULL,
   appFile = NULL,
   appDir = NULL,
-  port = 3000
+  port = 3000,
+  stdout = "|",
+  stderr = "|"
 )
 }
 \arguments{
@@ -33,6 +35,25 @@ expression that produces a Shiny app object.
 }}
 
 \item{port}{The TCP port that the application should listen on (defaults to 3000).}
+
+\item{stdout}{The name of the file the standard output of
+the child R process will be written to.
+If the child process runs with the \code{--slave} option (the default),
+then the commands are not echoed and will not be shown
+in the standard output. Also note that you need to call \code{print()}
+explicitly to show the output of the command(s).
+IF \code{NULL} (the default), then standard output is not returned, but
+it is recorded and included in the error object if an error happens.}
+
+\item{stderr}{The name of the file the standard error of
+the child R process will be written to.
+In particular \code{message()} sends output to the standard
+error. If nothing was sent to the standard error, then this file
+will be empty. This argument can be the same file as \code{stdout},
+in which case they will be correctly interleaved. If this is the
+string \code{"2>&1"}, then standard error is redirected to standard output.
+IF \code{NULL} (the default), then standard output is not returned, but
+it is recorded and included in the error object if an error happens.}
 }
 \description{
 Render Shiny Application in a Jupyter Notebook

--- a/man/runBackgroundApp.Rd
+++ b/man/runBackgroundApp.Rd
@@ -10,7 +10,9 @@ runBackgroundApp(
   appFile = NULL,
   appDir = NULL,
   port = getOption("shiny.port"),
-  host = getOption("shiny.host", "127.0.0.1")
+  host = getOption("shiny.host", "127.0.0.1"),
+  stdout = "|",
+  stderr = "|"
 )
 }
 \arguments{
@@ -38,6 +40,25 @@ expression that produces a Shiny app object.
 \item{host}{The IPv4 address that the application should listen on. Defaults
 to the \code{shiny.host} option, if set, or \code{"127.0.0.1"} if not. See
 Details.}
+
+\item{stdout}{The name of the file the standard output of
+the child R process will be written to.
+If the child process runs with the \code{--slave} option (the default),
+then the commands are not echoed and will not be shown
+in the standard output. Also note that you need to call \code{print()}
+explicitly to show the output of the command(s).
+IF \code{NULL} (the default), then standard output is not returned, but
+it is recorded and included in the error object if an error happens.}
+
+\item{stderr}{The name of the file the standard error of
+the child R process will be written to.
+In particular \code{message()} sends output to the standard
+error. If nothing was sent to the standard error, then this file
+will be empty. This argument can be the same file as \code{stdout},
+in which case they will be correctly interleaved. If this is the
+string \code{"2>&1"}, then standard error is redirected to standard output.
+IF \code{NULL} (the default), then standard output is not returned, but
+it is recorded and included in the error object if an error happens.}
 }
 \value{
 A \link[callr:r_process]{callr::r_process} object for the background Shiny app


### PR DESCRIPTION
This exposes `callr::r_bg()`'s `stdout`/`stderr` arguments so app logs can be recorded to specified files. 

Example:
![Screenshot 2023-02-16 at 12 52 54 PM](https://user-images.githubusercontent.com/1067915/219472870-ab07ef96-80e7-46c1-a820-067095a83ab6.png)
